### PR TITLE
Fix keywords and add git repo in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,10 +7,14 @@
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [
-    "['react'",
-    "'google",
-    "maps']"
+    "react",
+    "google",
+    "maps"
   ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Albosonic/googlemap-react.git"
+  },
   "author": "Alberto Madueno",
   "license": "ISC",
   "dependencies": {


### PR DESCRIPTION
The keywords in `package.json` had a little bit of extra characters in them, so those have been cleaned up. Additionally, on the [npm page](https://www.npmjs.com/package/googlemap-react) for this package, the GitHub repo doesn't show up on the right sidebar, which I think is because the repo was not listed in `package.json`, so that has also been added in this PR.

Great work man 🌮 🌮 